### PR TITLE
Adds unavailable and training context to spec

### DIFF
--- a/spec/apollo/bot/classifier_spec.rb
+++ b/spec/apollo/bot/classifier_spec.rb
@@ -20,4 +20,54 @@ describe Apollo::Bot::Classifier do
       end
     end
   end
+
+  context "when status is 'Unavailable'" do
+    before { @classifier.status = "Unavailable"}
+
+    describe "#available?" do
+      it "should return false" do
+        expect(@classifier.available?).to be false
+      end
+    end
+    describe "#unavailable?" do
+      it "should return true" do
+        expect(@classifier.unavailable?).to be true
+      end
+    end
+    describe "#non_existent?" do
+      it "should return false" do
+        expect(@classifier.non_existent?).to be false
+      end
+    end
+    describe "training?" do
+      it "should return false" do
+        expect(@classifier.training?).to be false
+      end
+    end
+  end
+
+  context "when status is 'Training'" do
+    before { @classifier.status = "Training" }
+
+    describe "#available?" do
+      it "should return false" do
+        expect(@classifier.available?).to be false
+      end
+    end
+    describe "#unavailable?" do
+      it "should return false" do
+        expect(@classifier.unavailable?).to be false
+      end
+    end
+    describe "#non_existent?" do
+      it "should return false" do
+        expect(@classifier.non_existent?).to be false
+      end
+    end
+    describe "training?" do
+      it "should return true" do
+        expect(@classifier.training?).to be true
+      end
+    end
+  end
 end


### PR DESCRIPTION
What does this PR do?

- Adds Unavailable and Training context to classifier spec 