### PR TITLE
Adds missing octothorpe to describe statement

### DIFF
--- a/spec/apollo/bot/classifier_spec.rb
+++ b/spec/apollo/bot/classifier_spec.rb
@@ -103,7 +103,7 @@ describe Apollo::Bot::Classifier do
         expect(@classifier.non_existent?).to be false
       end
     end
-    describe "training?" do
+    describe "#training?" do
       it "should return true" do
         expect(@classifier.training?).to be true
       end


### PR DESCRIPTION
What does this PR do?
- Adds missing '#' to Training statement